### PR TITLE
Handle dynamically created classes for which astng returns `_Yes`

### DIFF
--- a/DjangoLint/AstCheckers/utils.py
+++ b/DjangoLint/AstCheckers/utils.py
@@ -32,6 +32,8 @@ def nodeisinstance(node, klasses, check_base_classes=True):
         val = safe_infer(base)
         if not val:
             continue
+        if isinstance(val, astng.bases._Yes):
+            continue
 
         nodes = [val]
         if check_base_classes:


### PR DESCRIPTION
Fixes this:

```
Traceback (most recent call last):
  File "/home/users/patrys/.local/bin/django-lint", line 9, in <module>
    load_entry_point('django-lint==0.0.0', 'console_scripts', 'django-lint')()
  File "/home/users/patrys/lab/django-lint/DjangoLint/script.py", line 139, in main
    linter.check([target])
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/lint.py", line 493, in check
    self.check_astng_module(astng, walker, rawcheckers)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/lint.py", line 567, in check_astng_module
    walker.walk(astng)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/utils.py", line 520, in walk
    self.walk(child)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/utils.py", line 520, in walk
    self.walk(child)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/utils.py", line 517, in walk
    cb(astng)
  File "/home/users/patrys/lab/django-lint/DjangoLint/AstCheckers/model_methods.py", line 127, in visit_class
    if is_model(node):
  File "/home/users/patrys/lab/django-lint/DjangoLint/AstCheckers/utils.py", line 25, in is_model
    return nodeisinstance(node, ('django.db.models.base.Model',), **kwargs)
  File "/home/users/patrys/lab/django-lint/DjangoLint/AstCheckers/utils.py", line 44, in nodeisinstance
    for node in nodes:
TypeError: '_Yes' object is not iterable
```
