### PR TITLE
Fixed issue #4

### DIFF
--- a/DjangoLint/AstCheckers/settings.py
+++ b/DjangoLint/AstCheckers/settings.py
@@ -75,6 +75,11 @@ class SettingsChecker(BaseChecker):
         except AttributeError:
             return
 
+        try:
+            xs_iterable = iter(xs)
+        except TypeError:
+            return
+
         return [(x, x.value) for x in xs if isinstance(safe_infer(x), astng.Const)]
 
     def check_middleware(self, node):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/users/patrys/.local/bin/django-lint", line 9, in <module>
    load_entry_point('django-lint==0.0.0', 'console_scripts', 'django-lint')()
  File "/home/users/patrys/lab/django-lint/DjangoLint/script.py", line 139, in main
    linter.check([target])
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/lint.py", line 493, in check
    self.check_astng_module(astng, walker, rawcheckers)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/lint.py", line 567, in check_astng_module
    walker.walk(astng)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/utils.py", line 520, in walk
    self.walk(child)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/utils.py", line 520, in walk
    self.walk(child)
  File "/home/users/patrys/.local/lib64/python2.7/site-packages/pylint/utils.py", line 517, in walk
    cb(astng)
  File "/home/users/patrys/lab/django-lint/DjangoLint/AstCheckers/model_methods.py", line 127, in visit_class
    if is_model(node):
  File "/home/users/patrys/lab/django-lint/DjangoLint/AstCheckers/utils.py", line 25, in is_model
    return nodeisinstance(node, ('django.db.models.base.Model',), **kwargs)
  File "/home/users/patrys/lab/django-lint/DjangoLint/AstCheckers/utils.py", line 44, in nodeisinstance
    for node in nodes:
TypeError: '_Yes' object is not iterable
```
