### PR TITLE
It is for the compatibility with pylint 0.25.1

### DIFF
--- a/DjangoLint/script.py
+++ b/DjangoLint/script.py
@@ -127,7 +127,7 @@ def main():
     if options.pylint:
         checkers.initialize(linter)
         for msg in ('C0111', 'C0301'):
-            linter.disable_message(msg)
+            linter.disable(msg)
 
     AstCheckers.register(linter)
 


### PR DESCRIPTION
AttributeError: 'PyLinter' object has no attribute 'disable_message'
